### PR TITLE
Fix for "Please provide a valid CSC."

### DIFF
--- a/src/Message/CreditCard/AbstractRequest.php
+++ b/src/Message/CreditCard/AbstractRequest.php
@@ -31,6 +31,7 @@ abstract class AbstractRequest extends \Omnipay\Paytrace\Message\AbstractRequest
         $data['CC'] = $card->getNumber();
         $data['EXPYR'] = substr($card->getExpiryYear(), -2);
         $data['EXPMNTH'] = str_pad($card->getExpiryMonth(), 2, '0', STR_PAD_LEFT);
+        $data['CSC'] = $card->getCvv();
         return $data;
     }
 }


### PR DESCRIPTION
I was getting a "Please provide a valid CSC." response. I looked into it and found out the CSC field is not part of the request.